### PR TITLE
Harden Docker runtime to run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,6 @@ WORKDIR /app
 
 RUN npm ci --ignore-scripts --omit-dev
 
+USER node
+
 ENTRYPOINT ["node", "dist/index.js"]


### PR DESCRIPTION
Hi maintainers,

ProofLayer found that this Docker image currently starts as root. This PR adds an explicit non-root runtime user while leaving the existing build and entrypoint unchanged.

Why this helps:
- reduces container breakout blast radius if the MCP server or one of its dependencies is compromised
- follows the least-privilege default expected for published MCP server containers
- keeps the patch intentionally small and easy to review

Validation:
- npm ci && npm test: passed; ProofLayer Dockerfile scan: run-as-root warning removed
- Docker build could not be run from my local environment because the Docker daemon socket was unavailable.

Found with ProofLayer, an open-source scanner for AI agent and MCP security.
